### PR TITLE
Fix placeholder pine_slab recipe 

### DIFF
--- a/src/main/resources/data/woods_and_mires/recipes/pine_slab.json
+++ b/src/main/resources/data/woods_and_mires/recipes/pine_slab.json
@@ -6,11 +6,11 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "item": "woods_and_mires:pine_planks"
     }
   },
   "result": {
-    "item": "minecraft:acacia_slab",
+    "item": "woods_and_mires:pine_slab",
     "count": 6
   }
 }


### PR DESCRIPTION
Was wondering why I couldn't see the recipe in-game. Whoops!